### PR TITLE
🤖 Add capabilities for GitHub Actions

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-
+    name: 🏗 Build
     runs-on: ubuntu-latest
 
     steps:
@@ -23,3 +23,8 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: 🧪 Test
       run: dotnet test --no-restore --verbosity normal
+    - name: 📲 Publish to NuGet
+      uses: brandedoutcast/publish-nuget@v2.5.2
+      with:
+        PROJECT_FILE_PATH: SpookVooper.Api/SpookVooper.Api.csproj
+        NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SpookVooper.Api
 
+![.NET Core](https://github.com/SpikeViper/SpookVooper.Api/workflows/.NET%20Core/badge.svg) ![CodeQL](https://github.com/SpikeViper/SpookVooper.Api/workflows/CodeQL/badge.svg)
+
 The Open-Source official API for SpookVooper
 
 ## What is this?


### PR DESCRIPTION
GitHub Actions will now automatically publish the latest changes to NuGet.  
**NOTE:** In order for this to work, Spike needs to add a [new repository secret](https://github.com/SpikeViper/SpookVooper.Api/settings/secrets/actions/new) called `NUGET_API_KEY` (yes, caps do matter in this case) that contains a NuGet API Key that has permission to publish packages to NuGet.  
  
Everyone else can ignore this.